### PR TITLE
Add requirements.txt listing the python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ to run **aeneas** inside a virtualized Debian image.
 ```bash
 $ git clone https://github.com/readbeyond/aeneas.git
 $ cd aeneas
+$ pip install -r requirements.txt
 $ python check_dependencies.py
 ```
 

--- a/README.txt
+++ b/README.txt
@@ -87,6 +87,7 @@ Installation
 
     $ git clone https://github.com/readbeyond/aeneas.git
     $ cd aeneas
+    $ pip install -r requirements.txt
     $ python check_dependencies.py
 
 If the last command prints a success message, you have all the required

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+lxml
+BeautifulSoup
+numpy
+scikits.audiolab


### PR DESCRIPTION
Providing a [`requirements.txt`](https://pip.pypa.io/en/latest/user_guide.html#requirements-files) file should make it easier for people to install dependencies.



