### PR TITLE
Patched to build aeneas.cew on Mac (and Windows too).

### DIFF
--- a/aeneas/diagnostics.py
+++ b/aeneas/diagnostics.py
@@ -232,11 +232,6 @@ class Diagnostics(object):
 
         :rtype: bool
         """
-        if not gf.is_linux():
-            gf.print_warning(u"aeneas.cew     NOT AVAILABLE")
-            gf.print_info(u"  The Python C Extension cew is not available for your OS")
-            gf.print_info(u"  You can still run aeneas but it will be a bit slower (than Linux)")
-            return False
         if gf.can_run_c_extension("cew"):
             gf.print_success(u"aeneas.cew     COMPILED")
             return False

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,8 @@ EXTENSION_CMFCC = Extension(
 #EXTENSIONS = [EXTENSION_CDTW, EXTENSION_CMFCC, EXTENSION_CWAVE]
 
 EXTENSIONS = [EXTENSION_CDTW, EXTENSION_CMFCC]
-if IS_LINUX:
-    # cew is available only for Linux at the moment
-    EXTENSIONS.append(EXTENSION_CEW)
+
+EXTENSIONS.append(EXTENSION_CEW)
 
 setup(
     name="aeneas",


### PR DESCRIPTION
I have merged the patches from https://github.com/pettarin/espeakosx into the homebrew espeak to compile and install libespeak.
I've submitted a pull request against the espeak.rb formula, but now homebrew maintainers are considering dropping espeak from their official formula list, see https://github.com/Homebrew/homebrew-core/pull/2726 so it may be necessary to use my homebew tap from now on.

Add the tap:
`brew tap danielbair/tap`
Then install as any other formula:
`brew install danielbair/tap/espeak`
