### PR TITLE
Copy espeak.dll and espeak.lib to build location.

### DIFF
--- a/aeneas/diagnostics.py
+++ b/aeneas/diagnostics.py
@@ -194,9 +194,9 @@ class Diagnostics(object):
         :rtype: bool
         """
         if gf.can_run_c_extension("cdtw"):
-            gf.print_success(u"aeneas.cdtw    COMPILED")
+            gf.print_success(u"aeneas.cdtw    AVAILABLE")
             return False
-        gf.print_warning(u"aeneas.cdtw    NOT COMPILED")
+        gf.print_warning(u"aeneas.cdtw    NOT AVAILABLE")
         gf.print_info(u"  You can still run aeneas but it will be significantly slower")
         gf.print_info(u"  Please refer to the installation documentation for details")
         return True
@@ -211,9 +211,9 @@ class Diagnostics(object):
         :rtype: bool
         """
         if gf.can_run_c_extension("cmfcc"):
-            gf.print_success(u"aeneas.cmfcc   COMPILED")
+            gf.print_success(u"aeneas.cmfcc   AVAILABLE")
             return False
-        gf.print_warning(u"aeneas.cmfcc   NOT COMPILED")
+        gf.print_warning(u"aeneas.cmfcc   NOT AVAILABLE")
         gf.print_info(u"  You can still run aeneas but it will be significantly slower")
         gf.print_info(u"  Please refer to the installation documentation for details")
         return True
@@ -228,9 +228,9 @@ class Diagnostics(object):
         :rtype: bool
         """
         if gf.can_run_c_extension("cew"):
-            gf.print_success(u"aeneas.cew     COMPILED")
+            gf.print_success(u"aeneas.cew     AVAILABLE")
             return False
-        gf.print_warning(u"aeneas.cew     NOT COMPILED")
+        gf.print_warning(u"aeneas.cew     NOT AVAILABLE")
         gf.print_info(u"  You can still run aeneas but it will be a bit slower")
         gf.print_info(u"  Please refer to the installation documentation for details")
         return True

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ def prepare_cew_for_windows():
     """
     try:
         # copy espeak_sapi.dll to C:\Windows\System32\espeak.dll
-        espeak_dll_dst_path = "C:\\Windows\\System32\\espeak.dll"
+        espeak_dll_win_path = "C:\\Windows\\System32\\espeak.dll"
+        espeak_dll_dst_path = "aeneas\\cew\\espeak.dll"
         espeak_dll_src_paths = [
             "C:\\aeneas\\eSpeak\\espeak_sapi.dll",
             "C:\\sync\\eSpeak\\espeak_sapi.dll",
@@ -62,20 +63,21 @@ def prepare_cew_for_windows():
                     break
             if not found:
                 print("[WARN] Unable to find the eSpeak DLL, probably because you installed eSpeak in a non-standard location.")
-                print("[WARN] If you want to compile the C extension cew,")
-                print("[WARN] please copy espeak_sapi.dll from your eSpeak directory into %s" % espeak_dll_dst_path)
-                print("[WARN] and run the aeneas setup again.")
-                return False
+                print("[WARN] If you want to run aeneas with the C extension cew,")
+                print("[WARN] please copy espeak_sapi.dll from your eSpeak directory to %s" % espeak_dll_win_path)
+                # print("[WARN] and run the aeneas setup again.")
+                # return False
             elif not copied:
                 print("[WARN] Unable to copy the eSpeak DLL, probably because you are not running with admin privileges.")
-                print("[WARN] If you want to compile the C extension cew,")
-                print("[WARN] please copy espeak_sapi.dll from your eSpeak directory into %s" % espeak_dll_dst_path)
-                print("[WARN] and run the aeneas setup again.")
-                return False
+                print("[WARN] If you want to run aeneas with the C extension cew,")
+                print("[WARN] please copy espeak_sapi.dll from your eSpeak directory to %s" % espeak_dll_win_path)
+                # print("[WARN] and run the aeneas setup again.")
+                # return False
 
-        # copy thirdparty/espeak.lib to $PYTHON\libs\espeak.lib
+        # copy thirdparty\espeak.lib to $PYTHON\libs\espeak.lib
         espeak_lib_src_path = os.path.join(os.path.dirname(__file__), "thirdparty", "espeak.lib")
-        espeak_lib_dst_path = os.path.join(sys.prefix, "libs", "espeak.lib")
+        espeak_lib_dst_path = os.path.join(os.path.dirname(__file__), "espeak.lib")
+        #espeak_lib_dst_path = os.path.join(sys.prefix, "libs", "espeak.lib")
         if os.path.exists(espeak_lib_dst_path):
             print("[INFO] Found eSpeak LIB in %s" % espeak_lib_dst_path)
         else:
@@ -225,7 +227,7 @@ setup(
     package_data={
         "aeneas": ["res/*", "*.md"],
         "aeneas.cdtw": ["*.c", "*.h", "*.md"],
-        "aeneas.cew": ["*.c", "*.h", "*.md"],
+        "aeneas.cew": ["*.c", "*.h", "*.md", "*.dll"],
         "aeneas.cmfcc": ["*.c", "*.h", "*.md"],
         "aeneas.cwave": ["*.c", "*.h", "*.md"],
         "aeneas.extra": ["*.md"],


### PR DESCRIPTION
If espeak_sapi.dll cannot be found, only warn the user and provide instructions for a solution.
In diagnostics.py replace COMPILED with AVAILABLE for module info.
PS. I don't know if this will break builds on linux or mac.