### PR TITLE
Update PLATFORMS.md

### DIFF
--- a/wiki/PLATFORMS.md
+++ b/wiki/PLATFORMS.md
@@ -9,17 +9,21 @@
 | Ubuntu         | 64        | Yes        | Yes             |
 | Gentoo         | 64        | Yes        | Unknown         |
 | Slackware      | 64        | Yes        | Unknown         |
-| Mac OS X 10.9  | 64        | Yes        | Unknown         |
-| Mac OS X 10.10 | 64        | Yes        | Unknown         |
-| Mac OS X 10.11 | 64        | Yes        | Unknown         |
+| Mac OS X 10.7  | 64        | Yes        | Yes             |
+| Mac OS X 10.8  | 64        | Yes        | Yes             |
+| Mac OS X 10.9  | 64        | Yes        | Yes             |
+| Mac OS X 10.10 | 64        | Yes        | Yes             |
+| Mac OS X 10.11 | 64        | Yes        | Yes             |
 | Windows Vista  | 32        | Yes (1)    | Yes (1, 2)      |
+| Windows 7      | 32        | Yes (1)    | Yes (1, 2)      |
 | Windows 7      | 64        | Yes (1)    | Yes (1, 2)      |
-| Windows 8.1    | 64        | Yes (1)    | Unknown (1, 2)  |
+| Windows 8.1    | 32        | Yes (1)    | Yes (1, 2)      |
+| Windows 8.1    | 64        | Yes (1)    | Yes (1, 2)      |
 | Windows 10     | 64        | Yes (1)    | Yes (1, 2)      |
 
 **Notes**
 (1) The ``cew`` Python C extension to speed up text synthesis
-is available only on Linux, Mac OS X, and Windows 32 bit at the moment.
+is available on Linux, Mac OS X, and Windows 32 bit at the moment.
 (2) On Windows and Python 3.4/3.5, compiling the Python C extensions
 is quite complex; however, running **aeneas** in pure Python mode
 has been confirmed to work.


### PR DESCRIPTION
I've just tested aeneas 1.5.1 on Python 3.4/3.5 on Mac OS X 10.7 to 10.11 and it is working fine. This was from homebrew `brew install python3` and macports `sudo port install python34` setups.

I've also tested on Windows 7 and 8.1 32-bit and it is also working file.