### PR TITLE
add macOS TTS via the command line “say”

### DIFF
--- a/aeneas/synthesizer.py
+++ b/aeneas/synthesizer.py
@@ -41,6 +41,7 @@ from aeneas.ttswrappers.awsttswrapper import AWSTTSWrapper
 from aeneas.ttswrappers.espeakngttswrapper import ESPEAKNGTTSWrapper
 from aeneas.ttswrappers.espeakttswrapper import ESPEAKTTSWrapper
 from aeneas.ttswrappers.festivalttswrapper import FESTIVALTTSWrapper
+from aeneas.ttswrappers.macosttswrapper import MacOSTTSWrapper
 from aeneas.ttswrappers.nuancettswrapper import NuanceTTSWrapper
 import aeneas.globalfunctions as gf
 
@@ -78,10 +79,13 @@ class Synthesizer(Loggable):
     FESTIVAL = "festival"
     """ Select Festival wrapper """
 
+    MACOS = "macos"
+    """ Select macOS "say" wrapper """
+
     NUANCE = "nuance"
     """ Select Nuance TTS API wrapper """
 
-    ALLOWED_VALUES = [AWS, CUSTOM, ESPEAK, ESPEAKNG, FESTIVAL, NUANCE]
+    ALLOWED_VALUES = [AWS, CUSTOM, ESPEAK, ESPEAKNG, FESTIVAL, MACOS, NUANCE]
     """ List of all the allowed values """
 
     TAG = u"Synthesizer"
@@ -137,6 +141,9 @@ class Synthesizer(Loggable):
         elif requested_tts_engine == self.FESTIVAL:
             self.log(u"TTS engine: Festival")
             self.tts_engine = FESTIVALTTSWrapper(rconf=self.rconf, logger=self.logger)
+        elif requested_tts_engine == self.MACOS:
+            self.log(u"TTS engine: macOS")
+            self.tts_engine = MacOSTTSWrapper(rconf=self.rconf, logger=self.logger)
         else:
             self.log(u"TTS engine: eSpeak")
             self.tts_engine = ESPEAKTTSWrapper(rconf=self.rconf, logger=self.logger)

--- a/aeneas/tests/test_macosttswrapper.py
+++ b/aeneas/tests/test_macosttswrapper.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# aeneas is a Python/C library and a set of tools
+# to automagically synchronize audio and text (aka forced alignment)
+#
+# Copyright (C) 2012-2013, Alberto Pettarin (www.albertopettarin.it)
+# Copyright (C) 2013-2015, ReadBeyond Srl   (www.readbeyond.it)
+# Copyright (C) 2015-2016, Alberto Pettarin (www.albertopettarin.it)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from aeneas.tests.base_ttswrapper import TestBaseTTSWrapper
+from aeneas.ttswrappers.macosttswrapper import MacOSTTSWrapper
+
+
+class TestESPEAKNGTTSWrapper(TestBaseTTSWrapper):
+
+    TTS = u"macos"
+    TTS_PATH = u"/usr/bin/say"
+    TTS_CLASS = MacOSTTSWrapper
+    TTS_LANGUAGE = MacOSTTSWrapper.ENG
+    TTS_LANGUAGE_VARIATION = MacOSTTSWrapper.ENG_GBR
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aeneas/tools/execute_task.py
+++ b/aeneas/tools/execute_task.py
@@ -49,6 +49,7 @@ from aeneas.ttswrappers.awsttswrapper import AWSTTSWrapper
 from aeneas.ttswrappers.espeakngttswrapper import ESPEAKNGTTSWrapper
 from aeneas.ttswrappers.espeakttswrapper import ESPEAKTTSWrapper
 from aeneas.ttswrappers.festivalttswrapper import FESTIVALTTSWrapper
+from aeneas.ttswrappers.macosttswrapper import MacOSTTSWrapper
 from aeneas.ttswrappers.nuancettswrapper import NuanceTTSWrapper
 from aeneas.validator import Validator
 import aeneas.globalconstants as gc
@@ -399,6 +400,7 @@ class ExecuteTaskCLI(AbstractCLIProgram):
         "espeak": ESPEAKTTSWrapper.CODE_TO_HUMAN_LIST,
         "espeak-ng": ESPEAKNGTTSWrapper.CODE_TO_HUMAN_LIST,
         "festival": FESTIVALTTSWrapper.CODE_TO_HUMAN_LIST,
+        "macos": MacOSTTSWrapper.CODE_TO_HUMAN_LIST,
         "nuance": NuanceTTSWrapper.CODE_TO_HUMAN_LIST,
         "task_language": Language.CODE_TO_HUMAN_LIST,
         "is_text_type": TextFileFormat.ALLOWED_VALUES,

--- a/aeneas/ttswrappers/README.md
+++ b/aeneas/ttswrappers/README.md
@@ -1,4 +1,4 @@
-# aeneas TTS Wrappers 
+# aeneas TTS Wrappers
 
 This Python package contains the Python wrappers for several built-in
 TTS engines that can be used by ``aeneas``
@@ -18,6 +18,7 @@ Currently, the available TTS engines are:
 * `ESPEAKNGTTSWrapper` for `eSpeak-ng` (subprocess)
 * `FESTIVALTTSWrapper` for `Festival` (subprocess)
 * `NuanceTTSWrapper` for `Nuance TTS API` (Python calling remote Nuance API)
+* `MacOSTTSWrapper` for `macOS` (subprocess)
 
 Moreover, custom TTS wrappers can be specified at runtime.
 The wrapper must be implemented in a `CustomTTSWrapper` class,

--- a/aeneas/ttswrappers/macosttswrapper.py
+++ b/aeneas/ttswrappers/macosttswrapper.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# aeneas is a Python/C library and a set of tools
+# to automagically synchronize audio and text (aka forced alignment)
+#
+# Copyright (C) 2012-2013, Alberto Pettarin (www.albertopettarin.it)
+# Copyright (C) 2013-2015, ReadBeyond Srl   (www.readbeyond.it)
+# Copyright (C) 2015-2016, Alberto Pettarin (www.albertopettarin.it)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This module contains the following classes:
+
+* :class:`~aeneas.ttswrappers.macosttswrapper.MacOSTTSWrapper`,
+  a wrapper for the ``macOS`` "say" TTS engine.
+
+Please refer to
+https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/SpeechSynthesisProgrammingGuide/SpeechOverview/SpeechOverview.html
+for further details.
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from aeneas.language import Language
+from aeneas.ttswrappers.basettswrapper import BaseTTSWrapper
+
+
+class MacOSTTSWrapper(BaseTTSWrapper):
+    """
+    A wrapper for the ``macOS`` TTS engine.
+
+    This wrapper supports calling the TTS engine
+    via ``subprocess``.
+
+    Future support for calling via Python C extension
+    is planned.
+
+    In abstract terms, it performs one or more calls like ::
+
+        $ say -v voice_name -o /tmp/output_file.wav --data-format LEF32@22050 < text
+
+    To use this TTS engine, specify ::
+
+        "tts=macos"
+
+    in the ``RuntimeConfiguration`` object.
+
+    See :class:`~aeneas.ttswrappers.basettswrapper.BaseTTSWrapper`
+    for the available functions.
+    Below are listed the languages supported by this wrapper.
+
+    :param rconf: a runtime configuration
+    :type  rconf: :class:`~aeneas.runtimeconfiguration.RuntimeConfiguration`
+    :param logger: the logger object
+    :type  logger: :class:`~aeneas.logger.Logger`
+    """
+
+    ARA = Language.ARA
+    """ Arabic """
+
+    CES = Language.CES
+    """ Czech """
+
+    DAN = Language.DAN
+    """ Danish """
+
+    DEU = Language.DEU
+    """ German """
+
+    ELL = Language.ELL
+    """ Greek """
+
+    ENG = Language.ENG
+    """ English """
+
+    FIN = Language.FIN
+    """ Finnish """
+
+    FRA = Language.FRA
+    """ French """
+
+    HEB = Language.HEB
+    """ Hebrew """
+
+    HIN = Language.HIN
+    """ Hindi """
+
+    HUN = Language.HUN
+    """ Hungarian """
+
+    IND = Language.IND
+    """ Indonesian """
+
+    ITA = Language.ITA
+    """ Italian """
+
+    JPN = Language.JPN
+    """ Japanese """
+
+    KOR = Language.KOR
+    """ Korean """
+
+    NLD = Language.NLD
+    """ Dutch """
+
+    NOR = Language.NOR
+    """ Norwegian """
+
+    POL = Language.POL
+    """ Polish """
+
+    POR = Language.POR
+    """ Portuguese """
+
+    RON = Language.RON
+    """ Romanian """
+
+    RUS = Language.RUS
+    """ Russian """
+
+    SLK = Language.SLK
+    """ Slovak """
+
+    SPA = Language.SPA
+    """ Spanish """
+
+    SWE = Language.SWE
+    """ Swedish """
+
+    THA = Language.THA
+    """ Thia """
+
+    TUR = Language.TUR
+    """ Turkish """
+
+    ZHO = Language.ZHO
+    """ Chinese """
+
+    ENG_GBR = "eng-GBR"
+    """ English (GB) """
+
+    LANGUAGE_TO_VOICE_CODE = {
+        ARA: "Maged",
+        CES: "Zuzana",
+        DAN: "Sara",
+        DEU: "Anna",
+        ELL: "Melina",
+        ENG: "Alex",
+        FIN: "Satu",
+        FRA: "Thomas",
+        HEB: "Carmit",
+        HIN: "Lekha",
+        HUN: "Mariska",
+        IND: "Damayanti",
+        ITA: "Alice",
+        JPN: "Kyoko",
+        KOR: "Yuna",
+        NLD: "Xander",
+        NOR: "Nora",
+        POL: "Zosia",
+        POR: "Luciana",
+        RON: "Ioana",
+        RUS: "Yuri",
+        SLK: "Laura",
+        SPA: "Juan",
+        SWE: "Alva",
+        THA: "Kanya",
+        TUR: "Yelda",
+        ZHO: "Ting-Ting",
+        ENG_GBR: "Daniel"
+    }
+    DEFAULT_LANGUAGE = ENG
+
+    OUTPUT_AUDIO_FORMAT = ("pcm_s16le", 1, 22050)
+
+    HAS_SUBPROCESS_CALL = True
+
+    TAG = u"MacOSTTSWrapper"
+
+    def __init__(self, rconf=None, logger=None):
+        super(MacOSTTSWrapper, self).__init__(rconf=rconf, logger=logger)
+
+        self.set_subprocess_arguments([
+            u"say",                                 # path to say
+            u"-v",                                  # append "-v"
+            self.CLI_PARAMETER_VOICE_CODE_STRING,   # it will be replaced by the actual voice code
+            u"-o",                                  # append "-o"
+            self.CLI_PARAMETER_WAVE_PATH,           # it will be replaced by the actual output file
+            self.CLI_PARAMETER_TEXT_STDIN,          # text is read from stdin,
+            '--data-format',                        # set output data format
+            'LEF32@22050'                           # data format string
+        ])


### PR DESCRIPTION
* currently all voices listed/supported are the default voices included with macOS 10.12
* higher quality versions of those voices can be downloaded from the macOS Systems panel, not sure the best place to document this.



