### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: python
+
+cache: pip
+
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "nightly"
+
+addons:
+  apt:
+    sources:
+      - sourceline: "ppa:mc3man/trusty-media"
+    packages:
+      - ffmpeg
+      - espeak
+
+install: pip install -r requirements.txt
+
+script: python run_all_unit_tests.py --verbose
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: "nightly"
+  include:
+    - os: osx
+      language: generic
+      python: "3.6"
+      install:
+        - brew update
+        - brew install python3 ffmpeg espeak
+        - python3 -m venv venv
+        - source venv/bin/activate
+        - pip3 install -r requirements.txt
+      script: python3 run_all_unit_tests.py --verbose
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 BeautifulSoup4>=4.5.1
 lxml>=3.6.0
 numpy>=1.9
+tgt>=1.4.3


### PR DESCRIPTION
Run tests with python 2.7, 3.5, 3.6 and nightly on linux and 3.6 on macOS. Python nightly is allowed to fail.

(closes #52)