### PR TITLE
Fix nested numpy include dirs in build

### DIFF
--- a/aeneas/cdtw/cdtw_setup.py
+++ b/aeneas/cdtw/cdtw_setup.py
@@ -52,7 +52,7 @@ setup(
     version="1.7.3",
     description="Python C Extension for computing the DTW as fast as your bare metal allows.",
     ext_modules=[CMODULE],
-    include_dirs=[misc_util.get_numpy_include_dirs()]
+    include_dirs=misc_util.get_numpy_include_dirs()
 )
 
 print("\n[INFO] Module cdtw successfully compiled\n")

--- a/aeneas/cmfcc/cmfcc_setup.py
+++ b/aeneas/cmfcc/cmfcc_setup.py
@@ -53,7 +53,7 @@ setup(
     version="1.7.3",
     description="Python C Extension for computing the MFCCs as fast as your bare metal allows.",
     ext_modules=[CMODULE],
-    include_dirs=[misc_util.get_numpy_include_dirs()]
+    include_dirs=misc_util.get_numpy_include_dirs()
 )
 
 print("\n[INFO] Module cmfcc successfully compiled\n")

--- a/aeneas/cwave/cwave_setup.py
+++ b/aeneas/cwave/cwave_setup.py
@@ -52,7 +52,7 @@ setup(
     version="1.7.3",
     description="Python C Extension for for reading WAVE files.",
     ext_modules=[CMODULE],
-    include_dirs=[misc_util.get_numpy_include_dirs()]
+    include_dirs=misc_util.get_numpy_include_dirs()
 )
 
 print("\n[INFO] Module cwave successfully compiled\n")

--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ except ImportError:
     sys.exit(1)
 
 # to compile cdtw and cmfcc, we need to include the NumPy dirs
-INCLUDE_DIRS = [misc_util.get_numpy_include_dirs()]
+INCLUDE_DIRS = misc_util.get_numpy_include_dirs()
 
 # scripts to be installed globally
 # on Linux and Mac OS X, use the file without extension


### PR DESCRIPTION
I'm thinking this might be an issue on my side as I could not find any other complaints regarding this -- but I could not seem to compile aeneas (nor install through pip for that matter) without this modification.

The error which showed up was on the lines of this:

`gcc ... -I['/home/.../.local/lib/python2.7/site-packages/numpy/core/include'] ... -c ../cint/cint.c -o build/temp.linux-x86_64-2.7/aeneas/cint/cint.o" failed with exit status 1`

As you can see, it looks a bit strange with the include as a list. This then happens because `get_numpy_include_dirs()` returns a list, which we then wrap in another list.

Versioning:

Linux (Ubuntu 17.10)

Python 2.7.9

gcc 7.2.0

numpy 1.13.3