### PR TITLE
change macOSTTS output format so it doesn't need conversion

### DIFF
--- a/aeneas/tests/test_macosttswrapper.py
+++ b/aeneas/tests/test_macosttswrapper.py
@@ -27,7 +27,7 @@ from aeneas.tests.base_ttswrapper import TestBaseTTSWrapper
 from aeneas.ttswrappers.macosttswrapper import MacOSTTSWrapper
 
 
-class TestESPEAKNGTTSWrapper(TestBaseTTSWrapper):
+class TestMacOSTTSWrapper(TestBaseTTSWrapper):
 
     TTS = u"macos"
     TTS_PATH = u"/usr/bin/say"

--- a/aeneas/ttswrappers/macosttswrapper.py
+++ b/aeneas/ttswrappers/macosttswrapper.py
@@ -218,7 +218,7 @@ class MacOSTTSWrapper(BaseTTSWrapper):
     }
     DEFAULT_LANGUAGE = ENG
 
-    OUTPUT_AUDIO_FORMAT = ("pcm_s16le", 1, 22050)
+    OUTPUT_AUDIO_FORMAT = ("pcm_s16le", 1, 16000)
 
     HAS_SUBPROCESS_CALL = True
 
@@ -235,5 +235,5 @@ class MacOSTTSWrapper(BaseTTSWrapper):
             self.CLI_PARAMETER_WAVE_PATH,           # it will be replaced by the actual output file
             self.CLI_PARAMETER_TEXT_STDIN,          # text is read from stdin,
             u"--data-format",                       # set output data format
-            u"LEF32@22050"                          # data format string
+            u"LEI16@16000"                          # data format string
         ])


### PR DESCRIPTION
We were producing 32bit @ 22KHz wav files but telling the rest of the system they were 16bit @ 22KHz wav files.  To remove the ffmpeg conversion step I changed it so 'say' produces 16bit @ 16KHz wav files.  Now running `python -m aeneas.tools.synthesize_text -r="tts=macos" list "Hello.|My name is Alex." eng -v test.wav` produces a file that sounds the same as running `say -v Alex Hello. My name is Alex.`

Fixes #203 