### PR TITLE
docs: fix simple typo, subsring -> substring

### DIFF
--- a/aeneas/cfw/speech_tools/EST_String.h
+++ b/aeneas/cfw/speech_tools/EST_String.h
@@ -171,7 +171,7 @@ private:
 
     /**@name Chop out part of string */
     //@{
-    /// Locate subsring and chop.
+    /// Locate substring and chop.
     EST_String chop_internal(const char *s, int length, int pos, EST_chop_direction directionult) const;
     /// Chop at given position.
     EST_String chop_internal(int pos, int length, EST_chop_direction directionult) const;


### PR DESCRIPTION
There is a small typo in aeneas/cfw/speech_tools/EST_String.h.

Should read `substring` rather than `subsring`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md