### PR TITLE
add pyproject.toml for numpy requirement

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ include README.md
 include README.rst
 include requirements.txt
 include setupmeta.py
+include pyproject.toml
 recursive-include thirdparty *
 include VERSION
 recursive-include wiki *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy>=1.9"]


### PR DESCRIPTION
This PR adds a pyproject.toml file to address the need to manually install numpy before aeneas, which was preventing aeneas from installing correctly in a Heroku app.

I took the approach from [this PR](https://github.com/prody/ProDy/pull/806) on a project with the same issue. Based on the comments on that PR, it should work for any version of pip above 10 and be harmless for lower versions. I tested it in a Heroku deploy and was able to install aeneas directly from a requirements.txt file.